### PR TITLE
Don't panic while panicking

### DIFF
--- a/src/mint.rs
+++ b/src/mint.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::fs::File;
 use std::io::{Error, ErrorKind, Result};
 use std::path::{Path, PathBuf};
+use std::thread;
 
 use tempdir::TempDir;
 
@@ -102,6 +103,9 @@ impl Mint {
 
 impl Drop for Mint {
     fn drop(&mut self) {
+        if thread::panicking() {
+            return;
+        }
         let regen_var = env::var("REGENERATE_GOLDENFILES");
         if regen_var.is_ok() && regen_var.unwrap() == "1" {
             self.update_goldenfiles();

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -55,3 +55,15 @@ fn regeneration() {
 
     mint.update_goldenfiles();
 }
+
+#[test]
+#[should_panic(expected = "assertion failed")]
+fn external_panic() {
+    setup_file("tests/goldenfiles/panic.txt", "old");
+
+    let mut mint = Mint::new("tests/goldenfiles");
+    let mut file1 = mint.new_goldenfile("panic.txt").unwrap();
+
+    write!(file1, "new").unwrap();
+    assert!(false);
+}


### PR DESCRIPTION
Panicking while panicking results in an uninformative error message:
```
running 1 test
thread panicked while panicking. aborting.
```