### PR TITLE
Add binary file support

### DIFF
--- a/src/differs.rs
+++ b/src/differs.rs
@@ -1,22 +1,65 @@
 //! Functions for comparing files.
 
-use std::fs::File;
-use std::io::Read;
+use std::fs::{metadata, File};
+use std::io;
+use std::io::{BufReader, Read};
 use std::path::Path;
+
+use difference;
 
 /// A function that displays a diff and panics if two files to not match.
 pub type Differ = Box<Fn(&Path, &Path)>;
 
 /// Compare unicode text files. Print a colored diff and panic on failure.
 pub fn text_diff(old: &Path, new: &Path) {
-    assert_diff!(&read_file(old), &read_file(new), "\n", 0);
+    difference::assert_diff!(&read_file(old), &read_file(new), "\n", 0);
+}
+
+/// Panic if binary files differ with some basic information about where they
+/// differ.
+pub fn binary_diff(old: &Path, new: &Path) {
+    let old_len = file_len(old);
+    let new_len = file_len(new);
+    if old_len != new_len {
+        panic!(
+            "File sizes differ: Old file is {} bytes, new file is {} bytes",
+            old_len, new_len
+        );
+    }
+
+    let first_difference = file_byte_iter(old)
+        .zip(file_byte_iter(new))
+        .position(|(old_byte, new_byte)| old_byte != new_byte);
+
+    if let Some(position) = first_difference {
+        panic!("Files differ at byte {}", position + 1);
+    }
+}
+
+fn open_file(path: &Path) -> File {
+    check_io(File::open(path), "opening file", path)
+}
+
+fn file_byte_iter<'a>(path: &'a Path) -> impl Iterator<Item = u8> + 'a {
+    BufReader::new(open_file(path))
+        .bytes()
+        .map(move |b| check_io(b, "reading file", path))
+}
+
+fn file_len(path: &Path) -> u64 {
+    check_io(metadata(path), "getting file length", path).len()
 }
 
 fn read_file(path: &Path) -> String {
     let mut contents = String::new();
-    File::open(path)
-        .expect(&format!("Error opening file: {:?}", path))
-        .read_to_string(&mut contents)
-        .expect(&format!("Error reading file: {:?}", path));
-    return contents;
+    check_io(
+        open_file(path).read_to_string(&mut contents),
+        "reading file",
+        path,
+    );
+    contents
+}
+
+fn check_io<T>(x: Result<T, io::Error>, message: &str, path: &Path) -> T {
+    x.unwrap_or_else(|_| panic!("Error {}: {:?}", message, path))
 }

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -50,6 +50,12 @@ impl Mint {
         self.new_goldenfile_with_differ(&path, get_differ_for_path(&path))
     }
 
+    /// Create a new goldenfile with a binary differ. See
+    /// Mint::new_goldenfile_with_differ for full documentation.
+    pub fn new_binary_goldenfile<P: AsRef<Path>>(&mut self, path: P) -> Result<File> {
+        self.new_goldenfile_with_differ(&path, Box::new(binary_diff))
+    }
+
     /// Create a new goldenfile with the specified diff function.
     ///
     /// The returned file is actually a temporary file, not the goldenfile

--- a/tests/basics.rs
+++ b/tests/basics.rs
@@ -7,17 +7,24 @@ use std::path::Path;
 
 use goldenfile::Mint;
 
-fn setup_file(path: &str, contents: &str) {
+fn create_file(path: &str) -> File {
     let path = Path::new(path);
     fs::create_dir_all(path.parent().unwrap()).unwrap();
-    let mut file = File::create(path).unwrap();
-    write!(file, "{}", contents).unwrap();
+    File::create(path).unwrap()
+}
+
+fn setup_text_file(path: &str, contents: &str) {
+    write!(create_file(path), "{}", contents).unwrap();
+}
+
+fn setup_binary_file(path: &str, contents: &[u8]) {
+    create_file(path).write_all(contents).unwrap();
 }
 
 #[test]
 fn basic_usage() {
-    setup_file("tests/goldenfiles/basic_usage1.txt", "Hello world!");
-    setup_file("tests/goldenfiles/basic_usage2.txt", "foobar");
+    setup_text_file("tests/goldenfiles/basic_usage1.txt", "Hello world!");
+    setup_text_file("tests/goldenfiles/basic_usage2.txt", "foobar");
 
     let mut mint = Mint::new("tests/goldenfiles");
     let mut file1 = mint.new_goldenfile("basic_usage1.txt").unwrap();
@@ -28,10 +35,52 @@ fn basic_usage() {
 }
 
 #[test]
+fn binary_usage() {
+    setup_binary_file("tests/goldenfiles/binary_usage1.bin", b"");
+    setup_binary_file("tests/goldenfiles/binary_usage2.bin", b"\x00\x01\x02");
+
+    let mut mint = Mint::new("tests/goldenfiles");
+    let mut file1 = mint.new_binary_goldenfile("binary_usage1.bin").unwrap();
+    let mut file2 = mint.new_binary_goldenfile("binary_usage2.bin").unwrap();
+
+    file1.write_all(b"").unwrap();
+    file2.write_all(b"\x00\x01\x02").unwrap();
+}
+
+#[test]
+#[should_panic(expected = "File sizes differ: Old file is 2 bytes, new file is 3 bytes")]
+fn binary_different_size() {
+    setup_binary_file("tests/goldenfiles/binary_different_size.bin", b"\x00\x01");
+
+    let mut mint = Mint::new("tests/goldenfiles");
+    let mut file = mint
+        .new_binary_goldenfile("binary_different_size.bin")
+        .unwrap();
+
+    file.write_all(b"\x00\x01\x02").unwrap();
+}
+
+#[test]
+#[should_panic(expected = "Files differ at byte 3")]
+fn binary_different_content() {
+    setup_binary_file(
+        "tests/goldenfiles/binary_different_content.bin",
+        b"\x00\x01\x03",
+    );
+
+    let mut mint = Mint::new("tests/goldenfiles");
+    let mut file = mint
+        .new_binary_goldenfile("binary_different_content.bin")
+        .unwrap();
+
+    file.write_all(b"\x00\x01\x02").unwrap();
+}
+
+#[test]
 #[should_panic(expected = "foobar")]
 fn positive_diff() {
-    setup_file("tests/goldenfiles/positive_diff1.txt", "Hello world!");
-    setup_file("tests/goldenfiles/positive_diff2.txt", "foobar");
+    setup_text_file("tests/goldenfiles/positive_diff1.txt", "Hello world!");
+    setup_text_file("tests/goldenfiles/positive_diff2.txt", "foobar");
 
     let mut mint = Mint::new("tests/goldenfiles");
     let mut file1 = mint.new_goldenfile("positive_diff1.txt").unwrap();
@@ -43,8 +92,8 @@ fn positive_diff() {
 
 #[test]
 fn regeneration() {
-    setup_file("tests/goldenfiles/regeneration1.txt", "Junk");
-    setup_file("tests/goldenfiles/regeneration2.txt", "More junk");
+    setup_text_file("tests/goldenfiles/regeneration1.txt", "Junk");
+    setup_text_file("tests/goldenfiles/regeneration2.txt", "More junk");
 
     let mut mint = Mint::new("tests/goldenfiles");
     let mut file1 = mint.new_goldenfile("regeneration1.txt").unwrap();
@@ -59,7 +108,7 @@ fn regeneration() {
 #[test]
 #[should_panic(expected = "assertion failed")]
 fn external_panic() {
-    setup_file("tests/goldenfiles/panic.txt", "old");
+    setup_text_file("tests/goldenfiles/panic.txt", "old");
 
     let mut mint = Mint::new("tests/goldenfiles");
     let mut file1 = mint.new_goldenfile("panic.txt").unwrap();


### PR DESCRIPTION
This adds a `new_binary_goldenfile` and `binary_diff` functions. If the files differ in size, it'll report the sizes. If the files' contents differ and the sizes are the same, it'll report the index of the first different byte (as suggested in #1).