### PR TITLE
Address compilation and clippy warnings

### DIFF
--- a/src/differs.rs
+++ b/src/differs.rs
@@ -8,7 +8,7 @@ use std::path::Path;
 use difference;
 
 /// A function that displays a diff and panics if two files to not match.
-pub type Differ = Box<Fn(&Path, &Path)>;
+pub type Differ = Box<dyn Fn(&Path, &Path)>;
 
 /// Compare unicode text files. Print a colored diff and panic on failure.
 pub fn text_diff(old: &Path, new: &Path) {
@@ -40,7 +40,7 @@ fn open_file(path: &Path) -> File {
     check_io(File::open(path), "opening file", path)
 }
 
-fn file_byte_iter<'a>(path: &'a Path) -> impl Iterator<Item = u8> + 'a {
+fn file_byte_iter(path: &Path) -> impl Iterator<Item = u8> + '_ {
     BufReader::new(open_file(path))
         .bytes()
         .map(move |b| check_io(b, "reading file", path))

--- a/src/mint.rs
+++ b/src/mint.rs
@@ -35,13 +35,11 @@ impl Mint {
         let mint = Mint {
             path: path.as_ref().to_path_buf(),
             files: vec![],
-            tempdir: tempdir,
+            tempdir,
         };
-        fs::create_dir_all(&mint.path).expect(&format!(
-            "Failed to create goldenfile directory {:?}",
-            mint.path
-        ));
-        return mint;
+        fs::create_dir_all(&mint.path)
+            .unwrap_or_else(|_| panic!("Failed to create goldenfile directory {:?}", mint.path));
+        mint
     }
 
     /// Create a new goldenfile using a differ inferred from the file extension.
@@ -67,7 +65,7 @@ impl Mint {
         }
 
         let abs_path = self.tempdir.path().to_path_buf().join(path.as_ref());
-        let maybe_file = File::create(abs_path.clone());
+        let maybe_file = File::create(abs_path);
         if maybe_file.is_ok() {
             self.files.push((path.as_ref().to_path_buf(), differ));
         }
@@ -102,7 +100,8 @@ impl Mint {
             let new = self.tempdir.path().join(&file);
 
             println!("Updating {:?}.", file.to_str().unwrap());
-            fs::copy(&new, &old).expect(&format!("Error copying {:?} to {:?}.", &new, &old));
+            fs::copy(&new, &old)
+                .unwrap_or_else(|_| panic!("Error copying {:?} to {:?}.", &new, &old));
         }
     }
 }


### PR DESCRIPTION
- Use explicit dyn for trait in Differ definition.
- Remove unnecessary lifetime in file_byte_iter by using '_
- Replace ".expect" with "unwrap_or_else to avoid building the string
  in the caller, even when it's not used.