### PR TITLE
Support placing golden files in subdirectories

### DIFF
--- a/src/mint.rs
+++ b/src/mint.rs
@@ -65,6 +65,13 @@ impl Mint {
         }
 
         let abs_path = self.tempdir.path().to_path_buf().join(path.as_ref());
+        if let Some(abs_parent) = abs_path.parent() {
+            if abs_parent != self.tempdir.path() {
+                fs::create_dir_all(&abs_parent).unwrap_or_else(|_| {
+                    panic!("Failed to create temporary subdirectory {:?}", abs_parent)
+                });
+            }
+        }
         let maybe_file = File::create(abs_path);
         if maybe_file.is_ok() {
             self.files.push((path.as_ref().to_path_buf(), differ));

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -35,6 +35,17 @@ fn binary_match() {
 }
 
 #[test]
+fn subdir() {
+    fs::create_dir_all("tests/goldenfiles/subdir").unwrap();
+    write_text_file("tests/goldenfiles/subdir/file1.txt", "File in subdir");
+
+    let mut mint = Mint::new("tests/goldenfiles");
+    let mut file1 = mint.new_goldenfile("subdir/file1.txt").unwrap();
+
+    write!(file1, "File in subdir").unwrap();
+}
+
+#[test]
 #[should_panic(expected = "File sizes differ: Old file is 2 bytes, new file is 3 bytes")]
 fn binary_size_diff() {
     write_binary_file("tests/goldenfiles/binary_size_diff.bin", b"\x00\x01");


### PR DESCRIPTION
Replicate the subdirectory structure in tempdir when the relative path
passed to new_goldenfile/new_goldenfile_with_differ contains a
subdirectory.